### PR TITLE
Keep the container running even if the action produced truncated response.

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -296,7 +296,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
             // and instead clients must check if 'error' is in the JSON
             // PRESERVING OLD BEHAVIOR and will address defect in separate change
             complete(BadGateway, response)
-          } else if (activation.response.isContainerError) {
+          } else if (activation.response.isContainerError || activation.response.isTruncated) {
             complete(BadGateway, response)
           } else {
             complete(InternalServerError, response)

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ActivationResponseTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ActivationResponseTests.scala
@@ -51,7 +51,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
       {
         val response = ContainerResponse(okStatus = true, m.take(max.toBytes.toInt - 1), Some(m.length.B, max))
         val run = processRunResponseContent(Right(response), logger)
-        run.statusCode shouldBe DeveloperError
+        run.statusCode shouldBe Truncated
         run.result.get.asJsObject
           .fields(ERROR_FIELD) shouldBe truncatedResponse(response.entity, m.length.B, max).toJson
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -313,7 +313,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       def checkResponse(activation: ActivationResult) = {
         val response = activation.response
         response.success shouldBe false
-        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.Truncated)
         val msg = response.result.get.fields(ActivationResponse.ERROR_FIELD).convertTo[String]
         val expected = Messages.truncatedResponse((allowedSize + 10).B, allowedSize.B)
         withClue(s"is: ${msg.take(expected.length)}\nexpected: $expected") {


### PR DESCRIPTION
Keep the container running even if the action produced truncated response.

## Description
If a container sometimes produces replies that are greater than the allowed max size, that container cannot be reused. However, treating this in a similar fashion to unhandled exception or other developer error seems too heavy handed. Layer concurrency on this and you get a lot of failed activations and container churn due to a only slightly misbehaving action.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [X] I opened an issue to propose and discuss this change (#4750)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [X] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

